### PR TITLE
Update styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -240,3 +240,7 @@ tr {
     margin-top: -29px;
   }
 }
+
+.container article a {
+  word-break: break-all;
+}


### PR DESCRIPTION
Add `word-break: break-all;` to `a` tag to avoid of page overflow by very long links that causes mobile view zoomed.
